### PR TITLE
#11 Manual publication to BinTray

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ dependencies {
 
 ## Manual publishing to BinTray
 
+1. Make sure you are exporting the following environment variables.
+    1. `BINTRAY_USER` containing your user name on _BinTray_
+    1. `BINTRAY_API_KEY` containing your API key for _BinTray_. Go get your API key:
+        1. Go to [_Edit your profile_](https://bintray.com/profile/edit) on BinTray
+        1. Click _API Key_
+        1. Click _Copy to clipboard_ (an icon with 2 overlapping squares)
 1. Update the version number by changing variable `PUBLISH_VERSION` in [kotti.gradle](kotti.gradle).
     ```groovy
     def PUBLISH_VERSION = 0.2
@@ -75,9 +81,9 @@ dependencies {
 1. Go to the _Versions_ section and click on the version number you just published.
 1. Make sure all expected files in all components are present.
    Example with `kotti-core`:
-    - `kotti-core-0.2-javadoc.jar`
-    - `kotti-core-0.2-sources.jar`
-    - `kotti-core-0.2.jar`
-    - `kotti-core-0.2.pom`
+    1. `kotti-core-0.2-javadoc.jar`
+    1. `kotti-core-0.2-sources.jar`
+    1. `kotti-core-0.2.jar`
+    1. `kotti-core-0.2.pom`
 1. In the [the _Kotti_ repository](https://bintray.com/adeynack/kotti/kotti), in the _Notice_ (look for a gray bell),
    click _Publish_

--- a/README.md
+++ b/README.md
@@ -60,3 +60,24 @@ dependencies {
     compile "com.github.adeynack:kotti-core:0.1-SNAPSHOT"
 }
 ```
+
+## Manual publishing to BinTray
+
+1. Update the version number by changing variable `PUBLISH_VERSION` in [kotti.gradle](kotti.gradle).
+    ```groovy
+    def PUBLISH_VERSION = 0.2
+    ```
+1. Manually execute the _Gradle_ task for publishing to _BinTray_.
+    ```bash
+    ./gradlew bintrayUpload
+    ```
+1. Log to _BinTray_ and go to [the _Kotti_ repository](https://bintray.com/adeynack/kotti/kotti)
+1. Go to the _Versions_ section and click on the version number you just published.
+1. Make sure all expected files in all components are present.
+   Example with `kotti-core`:
+    - `kotti-core-0.2-javadoc.jar`
+    - `kotti-core-0.2-sources.jar`
+    - `kotti-core-0.2.jar`
+    - `kotti-core-0.2.pom`
+1. In the [the _Kotti_ repository](https://bintray.com/adeynack/kotti/kotti), in the _Notice_ (look for a gray bell),
+   click _Publish_

--- a/build.gradle
+++ b/build.gradle
@@ -9,15 +9,19 @@ For help on multi-project build:
 
 */
 
+def PUBLISH_VERSION = 0.1
+
 buildscript {
     ext.kotlin_version = '1.1.2-4'
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // Upgrade junit-platform-gradle-plugin to M4 once https://github.com/JetBrains/spek/issues/195 is fixed and released.
         classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-M3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
     }
 }
 
@@ -30,7 +34,7 @@ allprojects {
     apply plugin: 'java'
 
     group 'com.github.adeynack'
-    version '1.0-SNAPSHOT'
+    version "$PUBLISH_VERSION"
 
 }
 
@@ -41,6 +45,7 @@ subprojects {
     apply plugin: 'idea'
     apply plugin: 'org.junit.platform.gradle.plugin'
     apply plugin: 'maven-publish'
+    apply plugin: 'com.jfrog.bintray'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
@@ -68,6 +73,20 @@ subprojects {
             exclude group: 'org.jetbrains.kotlin'
         }
 
+        bintray {
+            user = System.getenv()["BINTRAY_USER"]
+            key = System.getenv()["BINTRAY_API_KEY"]
+            publications = ['MavenPub']
+            pkg {
+                repo = 'kotti'
+                name = 'kotti'
+                licenses = ['MIT']
+                vcsUrl = 'https://github.com/adeynack/kotti.git'
+                version {
+                    name = "$PUBLISH_VERSION"
+                }
+            }
+        }
     }
 
     // This is valid for `compileKotlin` and `compileTestKotlin`.
@@ -76,6 +95,16 @@ subprojects {
             jvmTarget = "1.8"
             freeCompilerArgs = ["-Xskip-runtime-version-check"]
         }
+    }
+
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+        classifier = 'javadoc'
+        from javadoc.destinationDir
     }
 
     junitPlatform {
@@ -89,10 +118,12 @@ subprojects {
 
     publishing {
         publications {
-            maven(MavenPublication) {
+            MavenPub(MavenPublication) {
                 from components.java
+                artifact sourcesJar
+                artifact javadocJar
                 groupId 'com.github.adeynack'
-                version '0.1-SNAPSHOT'
+                version "$PUBLISH_VERSION"
             }
         }
     }


### PR DESCRIPTION
closes #11 

Publication of artifacts is now possible on BinTray, but only manually. Instruction on how to publish are in the README file.