### PR TITLE
#17 JSON assertions + tests

### DIFF
--- a/kotti-tests/build.gradle
+++ b/kotti-tests/build.gradle
@@ -14,4 +14,5 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile project(':kotti-core')
+    compile 'org.skyscreamer:jsonassert:1.4.0'
 }

--- a/kotti-tests/src/main/kotlin/com/github/adeynack/kotti/tests/JsonAssertions.kt
+++ b/kotti-tests/src/main/kotlin/com/github/adeynack/kotti/tests/JsonAssertions.kt
@@ -1,0 +1,53 @@
+package com.github.adeynack.kotti.tests
+
+import org.skyscreamer.jsonassert.JSONCompare
+import org.skyscreamer.jsonassert.JSONCompareMode
+import org.skyscreamer.jsonassert.JSONParser.parseJSON
+
+object JsonAssertions {
+    /**
+     * Compares a [String] containing JSON to another one, expecting a strict equality.
+     * - not extensible (the [actual] value must not have more fields than the expected value)
+     * - strict array ordering
+     */
+    infix fun String?.shouldEqualJson(actual: String?) =
+        equalJson(this, actual, JSONCompareMode.STRICT, "is not equal to")
+
+    /**
+     * Compares a [String] containing JSON to another one, expecting at least a certain set of properties.
+     * - extensible (the [actual] value can have more fields than the expected value)
+     * - strict array ordering
+     */
+    infix fun String?.shouldContainJson(actual: String?) =
+        equalJson(this, actual, JSONCompareMode.STRICT_ORDER, "does not contain")
+
+    /**
+     * Compares a [String] containing JSON to another one, expecting at least a certain set of properties and
+     * being lenient on order of the elements inside of arrays.
+     * - extensible (the [actual] value can have more fields than the expected value)
+     * - lenient array ordering (items have to all be there, but the order does not count)
+     */
+    infix fun String?.shouldContainJsonLenientArrays(actual: String?) =
+        equalJson(this, actual, JSONCompareMode.LENIENT, "does not contain")
+
+    private fun equalJson(actual: String?, expected: String?, mode: JSONCompareMode, verb: String) {
+        val result = JSONCompare.compareJSON(expected, actual, mode)
+        if (!result.passed()) {
+            val msgActual = try {
+                parseJSON(actual).toString()
+            } catch(e: Exception) {
+                actual?.trim()
+            }
+            val msgExpected = try {
+                parseJSON(expected).toString()
+            } catch(e: Exception) {
+                expected?.trim()
+            }
+            val msgMessage = result.message.trimStart { it == '\n' }
+            throw JsonAssertionError("JSON value\n  $msgActual\n$verb\n  $msgExpected\nbecause:\n$msgMessage")
+        }
+    }
+
+}
+
+class JsonAssertionError(message: String) : AssertionError(message)

--- a/kotti-tests/src/main/kotlin/com/github/adeynack/kotti/tests/KotlinTestsImplementation.kt
+++ b/kotti-tests/src/main/kotlin/com/github/adeynack/kotti/tests/KotlinTestsImplementation.kt
@@ -1,5 +1,0 @@
-package com.github.adeynack.kotti.tests
-
-object KotlinTestsImplementation {
-    val value = true
-}

--- a/kotti-tests/src/test/kotlin/com/github/adeynack/kotti/tests/JsonAssertionsSpec.kt
+++ b/kotti-tests/src/test/kotlin/com/github/adeynack/kotti/tests/JsonAssertionsSpec.kt
@@ -1,0 +1,251 @@
+package com.github.adeynack.kotti.tests
+
+import com.github.adeynack.kotti.tests.JsonAssertions.shouldContainJson
+import com.github.adeynack.kotti.tests.JsonAssertions.shouldContainJsonLenientArrays
+import com.github.adeynack.kotti.tests.JsonAssertions.shouldEqualJson
+import org.amshove.kluent.shouldEqual
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+
+object JsonKluentSpec : Spek({
+
+    fun expectJsonAssertionError(f: () -> Unit): JsonAssertionError {
+        try {
+            f()
+            throw AssertionError("Expected `JsonAssertionError` was not thrown")
+        } catch(e: JsonAssertionError) {
+            return e
+        }
+    }
+
+    infix fun JsonAssertionError.withMessage(expectedMessage: String) {
+        this.message shouldEqual expectedMessage.trimMargin()
+    }
+
+    describe("Asserting with `shouldEqualJson`") {
+
+        it("should be positive when JSON objects are the same") {
+            val a = """{   "a": true,   "b": 42,   "c": null   }"""
+            val b = """{   "a": true,   "b": 42,   "c": null   }"""
+            a shouldEqualJson b
+        }
+
+        it("should be positive when JSON objects are the same, but properties are not in the same order") {
+            val a = """{   "a": true,   "b": 42,   "c": null   }"""
+            val b = """{   "a": true,   "c": null, "b": 42     }"""
+            a shouldEqualJson b
+        }
+
+        it("should be negative when a same property has different value") {
+            expectJsonAssertionError {
+                val a = """{   "a": true,   "b": 42,   "c": null   }"""
+                val b = """{   "a": true,   "b": 42,   "c": "asd"  }"""
+                a shouldEqualJson b
+            } withMessage """
+                |JSON value
+                |  {"a":true,"b":42,"c":null}
+                |is not equal to
+                |  {"a":true,"b":42,"c":"asd"}
+                |because:
+                |c
+                |Expected: asd
+                |     got: null
+                |"""
+        }
+
+        it("should be negative when the tested value has more properties than the expected") {
+            expectJsonAssertionError {
+                val a = """{   "a": true,   "b": 42,   "c": null, "d": true   }"""
+                val b = """{   "a": true,   "b": 42,   "c": null  }"""
+                a shouldEqualJson b
+            } withMessage """
+                |JSON value
+                |  {"a":true,"b":42,"c":null,"d":true}
+                |is not equal to
+                |  {"a":true,"b":42,"c":null}
+                |because:
+                |Unexpected: d
+                |"""
+        }
+
+        it("should be negative when the tested value a different array order") {
+            expectJsonAssertionError {
+                val a = """{   "a": true,   "b": [1,2,3],   "c": null  }"""
+                val b = """{   "a": true,   "b": [1,3,2],   "c": null  }"""
+                a shouldEqualJson b
+            } withMessage """
+                |JSON value
+                |  {"a":true,"b":[1,2,3],"c":null}
+                |is not equal to
+                |  {"a":true,"b":[1,3,2],"c":null}
+                |because:
+                |b[1]
+                |Expected: 3
+                |     got: 2
+                | ; b[2]
+                |Expected: 2
+                |     got: 3
+                |"""
+        }
+
+        it("should be negative when the tested value a different array values") {
+            expectJsonAssertionError {
+                val a = """{   "a": true,   "b": [1,2,3],   "c": null  }"""
+                val b = """{   "a": true,   "b": [1,2,4],   "c": null  }"""
+                a shouldEqualJson b
+            } withMessage """
+                |JSON value
+                |  {"a":true,"b":[1,2,3],"c":null}
+                |is not equal to
+                |  {"a":true,"b":[1,2,4],"c":null}
+                |because:
+                |b[2]
+                |Expected: 4
+                |     got: 3
+                |"""
+        }
+
+    }
+
+    describe("Asserting with `shouldContainJson`") {
+
+        it("should be positive when JSON objects are the same") {
+            val a = """{   "a": true,   "b": 42,   "c": null   }"""
+            val b = """{   "a": true,   "b": 42,   "c": null   }"""
+            a shouldContainJson b
+        }
+
+        it("should be positive when JSON objects are the same, but properties are not in the same order") {
+            val a = """{   "a": true,   "b": 42,   "c": null   }"""
+            val b = """{   "a": true,   "c": null, "b": 42     }"""
+            a shouldContainJson b
+        }
+
+        it("should be negative when a same property has different value") {
+            expectJsonAssertionError {
+                val a = """{   "a": true,   "b": 42,   "c": null   }"""
+                val b = """{   "a": true,   "b": 42,   "c": "asd"  }"""
+                a shouldContainJson b
+            } withMessage """
+                |JSON value
+                |  {"a":true,"b":42,"c":null}
+                |does not contain
+                |  {"a":true,"b":42,"c":"asd"}
+                |because:
+                |c
+                |Expected: asd
+                |     got: null
+                |"""
+        }
+
+        it("should be positive when the tested value has more properties than the expected") {
+            val a = """{   "a": true,   "b": 42,   "c": null, "d": true   }"""
+            val b = """{   "a": true,   "b": 42,   "c": null  }"""
+            a shouldContainJson b
+        }
+
+        it("should be negative when the tested value a different array order") {
+            expectJsonAssertionError {
+                val a = """{   "a": true,   "b": [1,2,3],   "c": null  }"""
+                val b = """{   "a": true,   "b": [1,3,2],   "c": null  }"""
+                a shouldContainJson b
+            } withMessage """
+                |JSON value
+                |  {"a":true,"b":[1,2,3],"c":null}
+                |does not contain
+                |  {"a":true,"b":[1,3,2],"c":null}
+                |because:
+                |b[1]
+                |Expected: 3
+                |     got: 2
+                | ; b[2]
+                |Expected: 2
+                |     got: 3
+                |"""
+        }
+
+        it("should be negative when the tested value a different array values") {
+            expectJsonAssertionError {
+                val a = """{   "a": true,   "b": [1,2,3],   "c": null  }"""
+                val b = """{   "a": true,   "b": [1,2,4],   "c": null  }"""
+                a shouldContainJson b
+            } withMessage """
+                |JSON value
+                |  {"a":true,"b":[1,2,3],"c":null}
+                |does not contain
+                |  {"a":true,"b":[1,2,4],"c":null}
+                |because:
+                |b[2]
+                |Expected: 4
+                |     got: 3
+                |"""
+        }
+
+    }
+
+    describe("Asserting with `shouldContainJsonLenientArrays`") {
+
+        it("should be positive when JSON objects are the same") {
+            val a = """{   "a": true,   "b": 42,   "c": null   }"""
+            val b = """{   "a": true,   "b": 42,   "c": null   }"""
+            a shouldContainJsonLenientArrays b
+        }
+
+        it("should be positive when JSON objects are the same, but properties are not in the same order") {
+            val a = """{   "a": true,   "b": 42,   "c": null   }"""
+            val b = """{   "a": true,   "c": null, "b": 42     }"""
+            a shouldContainJsonLenientArrays b
+        }
+
+        it("should be negative when a same property has different value") {
+            expectJsonAssertionError {
+                val a = """{   "a": true,   "b": 42,   "c": null   }"""
+                val b = """{   "a": true,   "b": 42,   "c": "asd"  }"""
+                a shouldContainJsonLenientArrays b
+            } withMessage """
+                |JSON value
+                |  {"a":true,"b":42,"c":null}
+                |does not contain
+                |  {"a":true,"b":42,"c":"asd"}
+                |because:
+                |c
+                |Expected: asd
+                |     got: null
+                |"""
+        }
+
+        it("should be positive when the tested value has more properties than the expected") {
+            val a = """{   "a": true,   "b": 42,   "c": null, "d": true   }"""
+            val b = """{   "a": true,   "b": 42,   "c": null  }"""
+            a shouldContainJsonLenientArrays b
+        }
+
+        it("should be positive when the tested value a different array order") {
+            val a = """{   "a": true,   "b": [1,2,3],   "c": null  }"""
+            val b = """{   "a": true,   "b": [1,3,2],   "c": null  }"""
+            a shouldContainJsonLenientArrays b
+        }
+
+        it("should be negative when the tested value a different array values") {
+            expectJsonAssertionError {
+                val a = """{   "a": true,   "b": [1,2,3],   "c": null  }"""
+                val b = """{   "a": true,   "b": [1,2,4],   "c": null  }"""
+                a shouldContainJsonLenientArrays b
+            } withMessage """
+                |JSON value
+                |  {"a":true,"b":[1,2,3],"c":null}
+                |does not contain
+                |  {"a":true,"b":[1,2,4],"c":null}
+                |because:
+                |b[]
+                |Expected: 4
+                |     but none found
+                | ; b[]
+                |Unexpected: 3
+                |"""
+        }
+
+    }
+
+})


### PR DESCRIPTION
closes #17 

Extension methods to `String` are now in place to assert JSON content:
- [`shouldEqualJson`](https://github.com/Adeynack/kotti/compare/17-json-assertions?expand=1#diff-db38698e58cf5b1874d86cbf72b643c3R13)
- [`shouldContainJson`](https://github.com/Adeynack/kotti/compare/17-json-assertions?expand=1#diff-db38698e58cf5b1874d86cbf72b643c3R21)
- [`shouldContainJsonLenientArrays`](https://github.com/Adeynack/kotti/compare/17-json-assertions?expand=1#diff-db38698e58cf5b1874d86cbf72b643c3R30)

See KotlinDoc of those functions for detail.