### PR TITLE
19 publish version 0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# CHANGELOG
+
+## 0.1 - 2017-06-09
+
+### core
+
+* NEW: Extensions to all types:
+  * [`orElse`](kotti-core/src/main/kotlin/com/github/adeynack/kotti/AnyExtensions.kt) to allow the "elvis operator"
+    logic with a block of code in the "if it was null" part.
+  * [`orElseWith`](kotti-core/src/main/kotlin/com/github/adeynack/kotti/AnyExtensions.kt) to allow the same as `orElse`,
+    but returning a potentially nullable result (some kind of `flatMap` on an `Option[T]`, to compare with Scala).
+* NEW: Extensions to collection types:
+  * [`filterByOneOf`](kotti-core/src/main/kotlin/com/github/adeynack/kotti/collections/FilterByOneOf.kt) to quickly
+    declare a composite filter where any of the provided predicate being positive will accept the current element. 
+  * [`toMap`](kotti-core/src/main/kotlin/com/github/adeynack/kotti/collections/ToMap.kt) to quickly declare a `Map`,
+    providing a key extractor or both the key and the value extractors.
+
+### swing
+
+* NEW: [`FlowPanel`](kotti-swing/src/main/kotlin/com/github/adeynack/kotti/swing/FlowPanel.kt), allowing quick creation of `JPanel` with
+  `FlowLayout` and its content.
+  
+### tests
+
+* NEW: [`JsonAssertion`](kotti-tests/src/main/kotlin/com/github/adeynack/kotti/tests/JsonAssertions.kt) to help
+  comparing strings comparing JSON and have a comprehensive error message when they are different.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ evolve over time.
    dependencies in client projects working).
 1. Commit in that branch
    ```bash
-   git add build.gradle && git commit -m "#19 Publish version 0.1"
+   git add build.gradle && git commit -m "#19 Published version 0.1"
    ```
 1. Create a pull request for this branch. Be careful in doing that during a "relative code-freeze" (make sure noone
    merges between the moment you tag and the moment you merge this pull request).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # kotti, aka _Kotlin: The Missing Bits_
 
 [![Build Status](https://travis-ci.org/Adeynack/kotti.svg?branch=master)](https://travis-ci.org/Adeynack/kotti)
+[![Download](https://api.bintray.com/packages/adeynack/kotti/kotti/images/download.svg)](https://bintray.com/adeynack/kotti/kotti/_latestVersion)
 
 # The Project
 
@@ -61,6 +62,57 @@ dependencies {
 }
 ```
 
+## Public version publication checklist
+
+**DISCLAIMER**: This is a first iteration of the process. Not the best way. Not bulletproof. But it is a start. This will
+evolve over time.
+
+1. Create an issue in [GitHub](https://github.com/Adeynack/kotti/issues/new) with the name `Publish version 0.1` (where
+   `0.1` is the version you are about to publish).
+1. Check out a clean version of `master`
+    ```bash
+    git checkout master
+    git pull
+    ```
+1. Create a branch with your issue number (ie: `19-publish-0.1` is the issue number is `19`)
+   ```bash
+   git checkout -b 19-publish-version-0.1
+   ```
+1. Check what the current version being worked on is in the [Gradle project file](build.gradle). Per instance:
+   ```groovy
+   def PUBLISH_VERSION = 0.1
+   ```
+   That means the current version that is about to be published is `0.1`.
+1. Add [release notes](CHANGELOG.md) for the current version.
+  * Add a new version at the BEGINNING of the list (so they are sorted by reverse date order)
+  * A new version starts with the version number and the date. ie: `## 0.1 - 2017-06-09`
+  * Group changes by modules (`core`, `swing`, `tests`, etc.)
+  * Describe briefly what was added, modified or deleted.
+1. Commit in that branch
+   ```bash
+   git add CHANGELOG.md && git commit -m "19 Release notes for version 0.1"
+   ```
+1. Tag the current commit as the end of the current version.
+   ```bash
+   git tag 0.1 && git push --tags
+   ```
+1. Publish to _BinTray_ using the instructions in the [Manual publishing to BinTray](#manual-publishing-to-bintray)
+   section of this document.
+1. Bump up the version number (usually, the 2nd digit) in the [Gradle file](build.gradle) for having in the `master`
+   branch afterwards the next version to be published (useful when developing and publishing locally, to keep
+   dependencies in client projects working).
+1. Commit in that branch
+   ```bash
+   git add build.gradle && git commit -m "19 Publish version 0.1"
+   ```
+1. Create a pull request for this branch. Be careful in doing that during a "relative code-freeze" (make sure noone
+   merges between the moment you tag and the moment you merge this pull request).
+   
+The end result is:
+* there is a GIT tag pointing at the exact status when published, with the right version number and the release notes.
+* the binaries, docs and sources are published to _BinTray_.
+* the master branch now points at the next version to be published.
+
 ## Manual publishing to BinTray
 
 1. Make sure you are exporting the following environment variables.
@@ -69,13 +121,14 @@ dependencies {
         1. Go to [_Edit your profile_](https://bintray.com/profile/edit) on BinTray
         1. Click _API Key_
         1. Click _Copy to clipboard_ (an icon with 2 overlapping squares)
-1. Update the version number by changing variable `PUBLISH_VERSION` in [kotti.gradle](kotti.gradle).
+1. Make sure the version number (variable `PUBLISH_VERSION` in [kotti.gradle](kotti.gradle)) is set to the exact version
+   you want to publish.
     ```groovy
-    def PUBLISH_VERSION = 0.2
+    def PUBLISH_VERSION = 0.1
     ```
 1. Manually execute the _Gradle_ task for publishing to _BinTray_.
     ```bash
-    ./gradlew bintrayUpload
+    ./gradlew clean bintrayUpload
     ```
 1. Log to _BinTray_ and go to [the _Kotti_ repository](https://bintray.com/adeynack/kotti/kotti)
 1. Go to the _Versions_ section and click on the version number you just published.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ evolve over time.
   * Describe briefly what was added, modified or deleted.
 1. Commit in that branch
    ```bash
-   git add CHANGELOG.md && git commit -m "19 Release notes for version 0.1"
+   git add CHANGELOG.md && git commit -m "#19 Release notes for version 0.1"
    ```
 1. Tag the current commit as the end of the current version.
    ```bash
@@ -103,7 +103,7 @@ evolve over time.
    dependencies in client projects working).
 1. Commit in that branch
    ```bash
-   git add build.gradle && git commit -m "19 Publish version 0.1"
+   git add build.gradle && git commit -m "#19 Publish version 0.1"
    ```
 1. Create a pull request for this branch. Be careful in doing that during a "relative code-freeze" (make sure noone
    merges between the moment you tag and the moment you merge this pull request).

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ For help on multi-project build:
 
 */
 
-def PUBLISH_VERSION = 0.1
+def PUBLISH_VERSION = 0.2
 
 buildscript {
     ext.kotlin_version = '1.1.2-4'


### PR DESCRIPTION
closes #19 

- [x] [Publication done on BinTray](https://bintray.com/adeynack/kotti/kotti/0.1)
- [x] Version bumped to 0.2
- [x] README now explains how to publish new version
- [x] CHANGELOG was created with information about version `0.1`.