### PR TITLE
#24 Target 1.6 instead of 1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+*.iml
 .gradle/
 build/
 g

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.2 - ????
+
+### General
+
+* Targeting 1.6 binaries, instead of 1.8, which causes problems when using the library and could be a no-go for Android
+  developers using lower versions of the JVM.
+* No more build dependency on the `jre8` flavour of the _Kotlin STD LIB_.
+
 ## 0.1 - 2017-06-09
 
 ### core
@@ -17,8 +25,8 @@
 
 ### swing
 
-* NEW: [`FlowPanel`](kotti-swing/src/main/kotlin/com/github/adeynack/kotti/swing/FlowPanel.kt), allowing quick creation of `JPanel` with
-  `FlowLayout` and its content.
+* NEW: [`FlowPanel`](kotti-swing/src/main/kotlin/com/github/adeynack/kotti/swing/FlowPanel.kt), allowing quick creation
+  of `JPanel` with `FlowLayout` and its content.
   
 ### tests
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ To execute the tests from all components:
 
 ## Local deployment
 
-To deploy to the local Maven repository (on the development machine) to allow other project to use the library:
+Deploying to the local Maven repository (on the development machine) allows other projects to use the library in its
+development state. It is suggested, to avoid confusion, to append `-SNAPSHOT` to `PUBLISH_VERSION` in the
+root [build.gradle](build.gradle) file.
 
 ```bash
 ./gradlew publishToMavenLocal
@@ -82,7 +84,7 @@ evolve over time.
    ```groovy
    def PUBLISH_VERSION = 0.1
    ```
-   That means the current version that is about to be published is `0.1`.
+   That means the current version that is about to be published is `0.1`. Make sure no `-SNAPSHOT` suffix is present.
 1. Add [release notes](CHANGELOG.md) for the current version.
   * Add a new version at the BEGINNING of the list (so they are sorted by reverse date order)
   * A new version starts with the version number and the date. ie: `## 0.1 - 2017-06-09`

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,10 @@ For help on multi-project build:
 
 */
 
-def PUBLISH_VERSION = 0.2
+def PUBLISH_VERSION = '0.2-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.1.2-4'
+    ext.kotlin_version = '1.1.2-5'
     repositories {
         mavenCentral()
         jcenter()
@@ -47,8 +47,8 @@ subprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
 
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = 1.6
+    targetCompatibility = 1.6
 
     repositories {
         mavenCentral()
@@ -58,7 +58,7 @@ subprojects {
 
     dependencies {
 
-        compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+        compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
         testCompile 'org.mockito:mockito-core:2.7.22'
         testCompile 'org.amshove.kluent:kluent:1.19'
@@ -73,27 +73,27 @@ subprojects {
             exclude group: 'org.jetbrains.kotlin'
         }
 
-        bintray {
-            user = System.getenv()["BINTRAY_USER"]
-            key = System.getenv()["BINTRAY_API_KEY"]
-            publications = ['MavenPub']
-            pkg {
-                repo = 'kotti'
-                name = 'kotti'
-                licenses = ['MIT']
-                vcsUrl = 'https://github.com/adeynack/kotti.git'
-                version {
-                    name = "$PUBLISH_VERSION"
-                }
+    }
+
+    bintray {
+        user = System.getenv()["BINTRAY_USER"]
+        key = System.getenv()["BINTRAY_API_KEY"]
+        publications = ['MavenPub']
+        pkg {
+            repo = 'kotti'
+            name = 'kotti'
+            licenses = ['MIT']
+            vcsUrl = 'https://github.com/adeynack/kotti.git'
+            version {
+                name = "$PUBLISH_VERSION"
             }
         }
     }
 
-    // This is valid for `compileKotlin` and `compileTestKotlin`.
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
+    // Compile the tests with JVM 1.8 (ie: for testing against streams)
+    compileTestKotlin {
         kotlinOptions {
             jvmTarget = "1.8"
-            freeCompilerArgs = ["-Xskip-runtime-version-check"]
         }
     }
 
@@ -127,5 +127,7 @@ subprojects {
             }
         }
     }
+
+
 
 }

--- a/kotti-core/build.gradle
+++ b/kotti-core/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.1.2-4'
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-apply plugin: 'kotlin'
-repositories {
-    mavenCentral()
-}
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 }

--- a/kotti-swing/build.gradle
+++ b/kotti-swing/build.gradle
@@ -1,17 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.1.2-4'
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-apply plugin: 'kotlin'
-repositories {
-    mavenCentral()
-}
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile project(':kotti-core')
 }

--- a/kotti-tests/build.gradle
+++ b/kotti-tests/build.gradle
@@ -1,18 +1,5 @@
-buildscript {
-    ext.kotlin_version = '1.1.2-4'
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-apply plugin: 'kotlin'
-repositories {
-    mavenCentral()
-}
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
     compile project(':kotti-core')
     compile 'org.skyscreamer:jsonassert:1.4.0'
 }
+


### PR DESCRIPTION
closes #24 

* Target 1.6 instead of 1.8
* Remove all "garbage" in the build.gradle files.
* kotti-core could depend on the kotti for jdk8 dependency only for tests (to tests things against streams, per instance)
* Remove dependency on `jre8` flavour of the STD LIB